### PR TITLE
EX-20821 LTC wallet name new format validation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,31 +29,31 @@
 
 ### Usage
 ```
-$address = \WalletAddressValidator\AddressFactory::create('BTC', 'BTC', '167FQQrBLUmhfMiYSEHaBprp34fphBiLm6');
+$address = \Exads\WalletAddressValidator\AddressFactory::create('BTC', 'BTC', '167FQQrBLUmhfMiYSEHaBprp34fphBiLm6');
 $address->isValid(); // true
 ```
 ```
-$address = \WalletAddressValidator\AddressFactory::create('NONE', 'BTC', '167FQQrBLUmhfMiYSEHaBprp34fphBiLm6');
+$address = \Exads\WalletAddressValidator\AddressFactory::create('NONE', 'BTC', '167FQQrBLUmhfMiYSEHaBprp34fphBiLm6');
 $address->isValid(); // \OutOfBoundsException
 ```
 
 
 ```
-\WalletAddressValidator\Validator::isValid('BTC', 'BTC', '167FQQrBLUmhfMiYSEHaBprp34fphBiLm6'); // true
+\Exads\WalletAddressValidator\Validator::isValid('BTC', 'BTC', '167FQQrBLUmhfMiYSEHaBprp34fphBiLm6'); // true
 ```
 
 ```
-\WalletAddressValidator\Validator::isValid('NONE', 'BTC', '167FQQrBLUmhfMiYSEHaBprp34fphBiLm6'); // false
+\Exads\WalletAddressValidator\Validator::isValid('NONE', 'BTC', '167FQQrBLUmhfMiYSEHaBprp34fphBiLm6'); // false
 ```
 
 ```
-$address = \WalletAddressValidator\AddressFactory::create('XLM', 'XLM', 'GBBALM76B5OUPOZCMFCNT5PVIFV3WTUYX3VVGC7FMN4ZPQLGCG2C4X3D');
+$address = \Exads\WalletAddressValidator\AddressFactory::create('XLM', 'XLM', 'GBBALM76B5OUPOZCMFCNT5PVIFV3WTUYX3VVGC7FMN4ZPQLGCG2C4X3D');
 $address->setParams(['memo' => '1034560979']);
 $address->isValid(); // true
 ```
 
 ```
-\WalletAddressValidator\Validator::isValid(
+\Exads\WalletAddressValidator\Validator::isValid(
    'XRP', 
    'XRP', 
    'ryBANkk28Mj71jRKAkt13U1X9ubztsGWZ',
@@ -62,7 +62,7 @@ $address->isValid(); // true
 ```
 
 ```
-\WalletAddressValidator\Validator::$networkAliases = [
+\Exads\WalletAddressValidator\Validator::$networkAliases = [
     'BTC' => [
         'SOMETHING-ELSE' => Network::BTC
     ]

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "require": {
         "ext-bcmath": "*",
-        "spomky-labs/cbor-php": "^2.0"
+        "spomky-labs/cbor-php": "^2.0",
+        "kielabokkie/bitcoin-address-validator": "^2.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
             "email": "ahmet.ozkurt@inlineyazilim.com"
         }
     ],
+    "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
             "Exads\\WalletAddressValidator\\": "src"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "azizozk/wallet-address-validator",
+    "name": "exads/wallet-address-validator",
     "description": "Crypto wallet address validator.",
     "keywords": ["crypto", "wallet", "address", "validator", "BTC", "USDT", "ETH", "LTC", "DOGE", "LINK", "ADA", "XRP"],
     "type": "library",
@@ -13,12 +13,12 @@
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
-            "WalletAddressValidator\\": "src"
+            "Exads\\WalletAddressValidator\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "WalletAddressValidator\\Test\\": "tests"
+            "Exads\\WalletAddressValidator\\Test\\": "tests"
         }
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
             "email": "ahmet.ozkurt@inlineyazilim.com"
         }
     ],
-    "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
             "Exads\\WalletAddressValidator\\": "src"

--- a/src/Address/AbstractAddress.php
+++ b/src/Address/AbstractAddress.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace WalletAddressValidator\Address;
+namespace Exads\WalletAddressValidator\Address;
 
-use WalletAddressValidator\Address\Validator\ValidatorInterface;
+use Exads\WalletAddressValidator\Address\Validator\ValidatorInterface;
 
 class AbstractAddress implements AddressInterface
 {

--- a/src/Address/AddressInterface.php
+++ b/src/Address/AddressInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address;
+namespace Exads\WalletAddressValidator\Address;
 
 interface AddressInterface
 {

--- a/src/Address/AddressInterface.php
+++ b/src/Address/AddressInterface.php
@@ -27,6 +27,9 @@ interface AddressInterface
     public const XMR = 'XMR';
     public const ZEC = 'ZEC';
 
+    public const ALGO = 'ALGO';
+    public const SOL = 'SOL';
+
     public function __construct(string $symbol, string $network, string $address);
 
     public function symbol(): string;

--- a/src/Address/Asset/Aave.php
+++ b/src/Address/Asset/Aave.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Aave extends AbstractAddress
 {

--- a/src/Address/Asset/Aave.php
+++ b/src/Address/Asset/Aave.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Aave extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Ada.php
+++ b/src/Address/Asset/Ada.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Ada as AdaValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Ada as AdaValidator;
 
 class Ada extends AbstractAddress
 {

--- a/src/Address/Asset/Algo.php
+++ b/src/Address/Asset/Algo.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Algo as AlgoValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Algo as AlgoValidator;
 
 class Algo extends AbstractAddress
 {

--- a/src/Address/Asset/Algo.php
+++ b/src/Address/Asset/Algo.php
@@ -4,16 +4,15 @@ namespace WalletAddressValidator\Address\Asset;
 
 use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use WalletAddressValidator\Address\Validator\Algo as AlgoValidator;
 
-class Mkr extends AbstractAddress
+class Algo extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ALGO => Network::ALGO,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ALGO => AlgoValidator::class
     ];
 }

--- a/src/Address/Asset/Ape.php
+++ b/src/Address/Asset/Ape.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Ape extends AbstractAddress
 {

--- a/src/Address/Asset/Ape.php
+++ b/src/Address/Asset/Ape.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Ape extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Axs.php
+++ b/src/Address/Asset/Axs.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Axs extends AbstractAddress
 {

--- a/src/Address/Asset/Axs.php
+++ b/src/Address/Asset/Axs.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Axs extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Bat.php
+++ b/src/Address/Asset/Bat.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Bat extends AbstractAddress
 {

--- a/src/Address/Asset/Bch.php
+++ b/src/Address/Asset/Bch.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Bch as BchValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Bch as BchValidator;
 
 class Bch extends AbstractAddress
 {

--- a/src/Address/Asset/Bit.php
+++ b/src/Address/Asset/Bit.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Bit extends AbstractAddress
 {

--- a/src/Address/Asset/Bit.php
+++ b/src/Address/Asset/Bit.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Bit extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Bnb.php
+++ b/src/Address/Asset/Bnb.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Bnb extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Bnb.php
+++ b/src/Address/Asset/Bnb.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Bnb extends AbstractAddress
 {

--- a/src/Address/Asset/Btc.php
+++ b/src/Address/Asset/Btc.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use \WalletAddressValidator\Address\Validator\Btc as BtcValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Btc as BtcValidator;
 
 class Btc extends AbstractAddress
 {

--- a/src/Address/Asset/Btg.php
+++ b/src/Address/Asset/Btg.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Btg as BtgValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Btg as BtgValidator;
 
 class Btg extends AbstractAddress
 {

--- a/src/Address/Asset/Btt.php
+++ b/src/Address/Asset/Btt.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\TRC20 as TrxValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\TRC20 as TrxValidator;
 
 class Btt extends AbstractAddress
 {

--- a/src/Address/Asset/Crv.php
+++ b/src/Address/Asset/Crv.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Crv extends AbstractAddress
 {

--- a/src/Address/Asset/Crv.php
+++ b/src/Address/Asset/Crv.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Crv extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Dash.php
+++ b/src/Address/Asset/Dash.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Dash as DashValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Dash as DashValidator;
 
 class Dash extends AbstractAddress
 {

--- a/src/Address/Asset/Doge.php
+++ b/src/Address/Asset/Doge.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Doge as DogeValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Doge as DogeValidator;
 
 class Doge extends AbstractAddress
 {

--- a/src/Address/Asset/Eos.php
+++ b/src/Address/Asset/Eos.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Eos as EosValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Eos as EosValidator;
 
 class Eos extends AbstractAddress
 {

--- a/src/Address/Asset/Etc.php
+++ b/src/Address/Asset/Etc.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Etc extends AbstractAddress
 {

--- a/src/Address/Asset/Eth.php
+++ b/src/Address/Asset/Eth.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Eth extends AbstractAddress
 {

--- a/src/Address/Asset/Fet.php
+++ b/src/Address/Asset/Fet.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Fet extends AbstractAddress
 {

--- a/src/Address/Asset/Fet.php
+++ b/src/Address/Asset/Fet.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Fet extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Fil.php
+++ b/src/Address/Asset/Fil.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Fil extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Fil.php
+++ b/src/Address/Asset/Fil.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Fil extends AbstractAddress
 {

--- a/src/Address/Asset/Hot.php
+++ b/src/Address/Asset/Hot.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Hot extends AbstractAddress
 {

--- a/src/Address/Asset/Imx.php
+++ b/src/Address/Asset/Imx.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Imx extends AbstractAddress
 {

--- a/src/Address/Asset/Imx.php
+++ b/src/Address/Asset/Imx.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Imx extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Ldo.php
+++ b/src/Address/Asset/Ldo.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Ldo extends AbstractAddress
 {

--- a/src/Address/Asset/Ldo.php
+++ b/src/Address/Asset/Ldo.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Ldo extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Link.php
+++ b/src/Address/Asset/Link.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Link extends AbstractAddress
 {

--- a/src/Address/Asset/Lrc.php
+++ b/src/Address/Asset/Lrc.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Lrc extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Lrc.php
+++ b/src/Address/Asset/Lrc.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Lrc extends AbstractAddress
 {

--- a/src/Address/Asset/Ltc.php
+++ b/src/Address/Asset/Ltc.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Ltc as LtcValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Ltc as LtcValidator;
 
 class Ltc extends AbstractAddress
 {

--- a/src/Address/Asset/Lto.php
+++ b/src/Address/Asset/Lto.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Lto extends AbstractAddress
 {

--- a/src/Address/Asset/Lto.php
+++ b/src/Address/Asset/Lto.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Lto extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Mana.php
+++ b/src/Address/Asset/Mana.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Mana extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Mana.php
+++ b/src/Address/Asset/Mana.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Mana extends AbstractAddress
 {

--- a/src/Address/Asset/Matic.php
+++ b/src/Address/Asset/Matic.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Matic extends AbstractAddress
 {

--- a/src/Address/Asset/Matic.php
+++ b/src/Address/Asset/Matic.php
@@ -6,14 +6,13 @@ use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
 use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Matic extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Mkr.php
+++ b/src/Address/Asset/Mkr.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
 class Mkr extends AbstractAddress
 {

--- a/src/Address/Asset/Shib.php
+++ b/src/Address/Asset/Shib.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
 
 class Snx extends AbstractAddress
 {

--- a/src/Address/Asset/Shib.php
+++ b/src/Address/Asset/Shib.php
@@ -4,16 +4,14 @@ namespace WalletAddressValidator\Address\Asset;
 
 use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
 
-class Mkr extends AbstractAddress
+class Snx extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::ETH => Network::ERC20,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::ERC20 => EthValidator::class
     ];
 }

--- a/src/Address/Asset/Sol.php
+++ b/src/Address/Asset/Sol.php
@@ -4,16 +4,15 @@ namespace WalletAddressValidator\Address\Asset;
 
 use WalletAddressValidator\Address\AbstractAddress;
 use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use WalletAddressValidator\Address\Validator\Sol as SolValidator;
 
-class Mkr extends AbstractAddress
+class Sol extends AbstractAddress
 {
     protected $networkAlias = [
-        self::MKR => Network::ERC20,
-        self::ETH => Network::ERC20
+        self::SOL => Network::SOL,
     ];
 
     protected $validators = [
-        Network::ERC20 => EthValidator::class,
+        Network::SOL => SolValidator::class
     ];
 }

--- a/src/Address/Asset/Sol.php
+++ b/src/Address/Asset/Sol.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Sol as SolValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Sol as SolValidator;
 
 class Sol extends AbstractAddress
 {

--- a/src/Address/Asset/Trx.php
+++ b/src/Address/Asset/Trx.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\TRC20 as TrxValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\TRC20 as TrxValidator;
 
 class Trx extends AbstractAddress
 {

--- a/src/Address/Asset/Usdt.php
+++ b/src/Address/Asset/Usdt.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
-use WalletAddressValidator\Address\Validator\OMNI as UsdtValidator;
-use WalletAddressValidator\Address\Validator\TRC20 as TrxValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\ERC20 as EthValidator;
+use Exads\WalletAddressValidator\Address\Validator\OMNI as UsdtValidator;
+use Exads\WalletAddressValidator\Address\Validator\TRC20 as TrxValidator;
 
 class Usdt extends AbstractAddress
 {

--- a/src/Address/Asset/Usdt.php
+++ b/src/Address/Asset/Usdt.php
@@ -18,7 +18,9 @@ class Usdt extends AbstractAddress
 
     protected $validators = [
         Network::ERC20 => EthValidator::class,
+        Network::TRC20 => TrxValidator::class,
+        Network::BEP20 => EthValidator::class,
+        Network::POLYGON => EthValidator::class,
         Network::OMNI => UsdtValidator::class,
-        Network::TRC20 => TrxValidator::class
     ];
 }

--- a/src/Address/Asset/Xem.php
+++ b/src/Address/Asset/Xem.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Xem as XemValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Xem as XemValidator;
 
 class Xem extends AbstractAddress
 {

--- a/src/Address/Asset/Xlm.php
+++ b/src/Address/Asset/Xlm.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Xlm as XlmValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Xlm as XlmValidator;
 
 class Xlm extends AbstractAddress
 {

--- a/src/Address/Asset/Xmr.php
+++ b/src/Address/Asset/Xmr.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Xmr as XmrValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Xmr as XmrValidator;
 
 class Xmr extends AbstractAddress
 {

--- a/src/Address/Asset/Xrp.php
+++ b/src/Address/Asset/Xrp.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Xrp as XrpValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Xrp as XrpValidator;
 
 class Xrp extends AbstractAddress
 {

--- a/src/Address/Asset/Zec.php
+++ b/src/Address/Asset/Zec.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Asset;
+namespace Exads\WalletAddressValidator\Address\Asset;
 
-use WalletAddressValidator\Address\AbstractAddress;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\Address\Validator\Zec as ZecValidator;
+use Exads\WalletAddressValidator\Address\AbstractAddress;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\Address\Validator\Zec as ZecValidator;
 
 class Zec extends AbstractAddress
 {

--- a/src/Address/Network.php
+++ b/src/Address/Network.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address;
+namespace Exads\WalletAddressValidator\Address;
 
 class Network
 {

--- a/src/Address/Network.php
+++ b/src/Address/Network.php
@@ -21,4 +21,7 @@ class Network
     public const XMR = 'XMR';
     public const XRP = 'XRP';
     public const ZEC = 'ZEC';
+
+    public const ALGO = 'ALGO';
+    public const SOL = 'SOL';
 }

--- a/src/Address/Network.php
+++ b/src/Address/Network.php
@@ -6,6 +6,8 @@ class Network
 {
     public const ERC20 = 'ERC20';
     public const TRC20 = 'TRC20';
+    public const BEP20 = 'BEP20';
+    public const POLYGON  = 'POLYGON';
     public const ADA = 'ADA';
     public const BCH = 'BCH';
     public const BTC = 'BTC';

--- a/src/Address/Validator/AbstractBase58.php
+++ b/src/Address/Validator/AbstractBase58.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\AddressInterface;
-use WalletAddressValidator\Address\Validator\Codec\Base58;
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base58;
 
 abstract class AbstractBase58 implements ValidatorInterface
 {

--- a/src/Address/Validator/Ada.php
+++ b/src/Address/Validator/Ada.php
@@ -31,6 +31,10 @@ class Ada extends AbstractBase58
             $decoder = new Decoder(new Tag\TagObjectManager(), new OtherObject\OtherObjectManager());
             $addrData = $decoder->decode($stream)->getNormalizedData();
 
+            if (!is_array($addrData) || !isset($addrData[1])) {
+                return false;
+            }
+
             if (($innerCrc = (int) $addrData[1] ?? 0) < 1) {
                 return false;
             }

--- a/src/Address/Validator/Ada.php
+++ b/src/Address/Validator/Ada.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 use CBOR\Decoder;
 use CBOR\OtherObject;
 use CBOR\Tag;
 use CBOR\StringStream;
-use WalletAddressValidator\Address\Validator\Codec\Base58;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base58;
 
 /**
  * @see https://docs.cardano.org/projects/cardano-wallet/en/latest/About-Address-Format---Byron.html

--- a/src/Address/Validator/Algo.php
+++ b/src/Address/Validator/Algo.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 use RuntimeException;
-use WalletAddressValidator\Address\AddressInterface;
-use WalletAddressValidator\Address\Validator\Codec\Base32;
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base32;
 
 class Algo implements ValidatorInterface
 {

--- a/src/Address/Validator/Algo.php
+++ b/src/Address/Validator/Algo.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WalletAddressValidator\Address\Validator;
+
+use RuntimeException;
+use WalletAddressValidator\Address\AddressInterface;
+use WalletAddressValidator\Address\Validator\Codec\Base32;
+
+class Algo implements ValidatorInterface
+{
+    /** @var int */
+    const NACL_PUBLIC_KEY_LENGTH = 32;
+    const NACL_HASH_BYTES_LENGTH = 32;
+    const ALGORAND_ADDRESS_BYTE_LENGTH = 36;
+    const ALGORAND_CHECKSUM_BYTE_LENGTH = 4;
+    const ALGORAND_ADDRESS_LENGTH = 58;
+
+    private AddressInterface $address;
+
+    public function __construct(AddressInterface $address)
+    {
+        $this->address = $address;
+    }
+
+    public function validate(): bool
+    {
+        try {
+            return $this->validateWithExceptions();
+        } catch (RuntimeException $e) {
+        }
+
+        return false;
+    }
+
+    /**
+     * @return bool
+     * @throws RuntimeException
+     */
+    public function validateWithExceptions()
+    {
+        if (strlen($this->address->address()) !== self::ALGORAND_ADDRESS_LENGTH) {
+            throw new RuntimeException('Address has invalid length');
+        }
+
+        $decodedAddress = $this->decodeAddress();
+        $checksumHash = unpack('C*', hash('sha512/256', pack('C*', ...$decodedAddress['publicKey']), true));
+        $checksum = array_slice($checksumHash, self::NACL_HASH_BYTES_LENGTH - self::ALGORAND_CHECKSUM_BYTE_LENGTH, self::NACL_HASH_BYTES_LENGTH);
+
+        if ($decodedAddress['checksum'] !== $checksum) {
+            throw new RuntimeException('Address is invalid');
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array
+     */
+    protected function decodeAddress()
+    {
+        $decodedAddress = unpack('C*', Base32::decode($this->address->address()));
+        $publicKey = array_slice($decodedAddress, 0, self::ALGORAND_ADDRESS_BYTE_LENGTH - self::ALGORAND_CHECKSUM_BYTE_LENGTH);
+        $checksum = array_slice($decodedAddress, self::NACL_PUBLIC_KEY_LENGTH, self::ALGORAND_ADDRESS_BYTE_LENGTH);
+
+        return [
+            'publicKey' => $publicKey,
+            'checksum' => $checksum,
+        ];
+    }
+}

--- a/src/Address/Validator/Bch.php
+++ b/src/Address/Validator/Bch.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\AddressInterface;
-use WalletAddressValidator\Address\Validator\Support\CashAddress;
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Support\CashAddress;
 
 class Bch extends AbstractBase58
 {

--- a/src/Address/Validator/Btc.php
+++ b/src/Address/Validator/Btc.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 class Btc extends AbstractBase58
 {

--- a/src/Address/Validator/Btg.php
+++ b/src/Address/Validator/Btg.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 class Btg extends AbstractBase58
 {

--- a/src/Address/Validator/Codec/Base32.php
+++ b/src/Address/Validator/Codec/Base32.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator\Codec;
+namespace Exads\WalletAddressValidator\Address\Validator\Codec;
 
 class Base32
 {

--- a/src/Address/Validator/Codec/Base58.php
+++ b/src/Address/Validator/Codec/Base58.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator\Codec;
+namespace Exads\WalletAddressValidator\Address\Validator\Codec;
 
 class Base58
 {

--- a/src/Address/Validator/Codec/Keccak.php
+++ b/src/Address/Validator/Codec/Keccak.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator\Codec;
+namespace Exads\WalletAddressValidator\Address\Validator\Codec;
 
 final class Keccak
 {

--- a/src/Address/Validator/Dash.php
+++ b/src/Address/Validator/Dash.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 class Dash extends AbstractBase58
 {

--- a/src/Address/Validator/Doge.php
+++ b/src/Address/Validator/Doge.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 class Doge extends AbstractBase58
 {

--- a/src/Address/Validator/ERC20.php
+++ b/src/Address/Validator/ERC20.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\AddressInterface;
-use WalletAddressValidator\Address\Validator\Codec\Keccak;
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Keccak;
 
 class ERC20 implements ValidatorInterface
 {

--- a/src/Address/Validator/Eos.php
+++ b/src/Address/Validator/Eos.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\AddressInterface;
 
 class Eos implements ValidatorInterface
 {

--- a/src/Address/Validator/Ltc.php
+++ b/src/Address/Validator/Ltc.php
@@ -2,23 +2,50 @@
 
 namespace Exads\WalletAddressValidator\Address\Validator;
 
-class Ltc extends AbstractBase58
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Ltc\Base58 as LtcBase58;
+use Exads\WalletAddressValidator\Address\Validator\Ltc\Bech32 as LtcBech32;
+
+class Ltc implements ValidatorInterface
 {
-    const DEPRECATED_ADDRESS_VERSION = '05';
 
-    protected $deprecatedAllowed = true;
+    private const VALIDATOR_DEFAULT = LtcBase58::class;
+    private AddressInterface $address;
 
-    protected $base58PrefixToHexVersion = [
-        'L' => '30',
-        'M' => '32',
-        '3' => self::DEPRECATED_ADDRESS_VERSION
+    // map prefix to validator class
+    private array $prefixes = [
+        'ltc1' => LtcBech32::class,
+        'tltc1' => LtcBech32::class,
     ];
 
-    protected function validateVersion($version): bool
+
+    public function __construct(AddressInterface $address)
     {
-        if ($this->addressVersion === self::DEPRECATED_ADDRESS_VERSION && !$this->deprecatedAllowed) {
-            return false;
+        $this->address = $address;
+    }
+
+    public function validate(): bool
+    {
+        return $this->validator()->validate();
+    }
+
+
+
+    private function validator(): ValidatorInterface
+    {
+        foreach ($this->prefixes as $prefix => $class){
+            if( $this->hasPrefix($this->address->address(), $prefix) ){
+                return new $class($this->address);
+            }
         }
-        return hexdec($version) === hexdec($this->addressVersion);
+
+        $class = self::VALIDATOR_DEFAULT;
+        return new $class($this->address);
+    }
+
+
+    private function hasPrefix(string $address, string $prefix): bool
+    {
+        return substr($address, 0, strlen($prefix)) === $prefix;
     }
 }

--- a/src/Address/Validator/Ltc.php
+++ b/src/Address/Validator/Ltc.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 class Ltc extends AbstractBase58
 {

--- a/src/Address/Validator/Ltc/Base58.php
+++ b/src/Address/Validator/Ltc/Base58.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Exads\WalletAddressValidator\Address\Validator\Ltc;
+
+use Exads\WalletAddressValidator\Address\Validator\AbstractBase58;
+
+class Base58 extends AbstractBase58
+{
+    const DEPRECATED_ADDRESS_VERSION = '05';
+
+    protected $deprecatedAllowed = true;
+
+    protected $base58PrefixToHexVersion = [
+        'L' => '30',
+        'M' => '32',
+        '3' => self::DEPRECATED_ADDRESS_VERSION
+    ];
+
+    protected function validateVersion($version): bool
+    {
+        if ($this->addressVersion === self::DEPRECATED_ADDRESS_VERSION && !$this->deprecatedAllowed) {
+            return false;
+        }
+        return hexdec($version) === hexdec($this->addressVersion);
+    }
+}

--- a/src/Address/Validator/Ltc/Bech32.php
+++ b/src/Address/Validator/Ltc/Bech32.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Exads\WalletAddressValidator\Address\Validator\Ltc;
+
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\ValidatorInterface;
+use Kielabokkie\Bitcoin\Bech32 as KielabokkieBech32;
+use Kielabokkie\Bitcoin\Exceptions\Bech32Exception;
+
+class Bech32 implements ValidatorInterface
+{
+
+    private AddressInterface $address;
+    private KielabokkieBech32 $converter;
+
+
+    public function __construct(AddressInterface $address)
+    {
+        $this->address = $address;
+        $this->converter = new KielabokkieBech32();
+    }
+
+    public function validate(): bool
+    {
+        // try to decode address with different algo version
+        // address is valid if no exception returned
+        foreach ([$this->converter::BECH32, $this->converter::BECH32M] as $encoding){
+            try{
+                $this->converter->decodeSegwit(
+                    $this->hrpFromAddress(),
+                    $this->address->address(),
+                    $encoding
+                );
+                return true;
+            }catch (Bech32Exception $e){
+                // ignore exception
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get human-readable part from the wallet address
+    */
+    private function hrpFromAddress(): string
+    {
+        if( preg_match("/^(\S*)1.*$/U", $this->address->address(), $matches) !==1) {
+            return "";
+        }
+        return $matches[1];
+    }
+
+}

--- a/src/Address/Validator/OMNI.php
+++ b/src/Address/Validator/OMNI.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 class OMNI extends AbstractBase58
 {

--- a/src/Address/Validator/Sol.php
+++ b/src/Address/Validator/Sol.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace WalletAddressValidator\Address\Validator;
+
+use RuntimeException;
+use WalletAddressValidator\Address\AddressInterface;
+use WalletAddressValidator\Address\Validator\Codec\Base58;
+
+class Sol implements ValidatorInterface
+{
+    private const MIN_LENGTH = 40;
+
+    private AddressInterface $address;
+
+    public function __construct(AddressInterface $address)
+    {
+        $this->address = $address;
+    }
+
+    public function validate(): bool
+    {
+        try {
+            return $this->validateWithExceptions();
+        } catch (RuntimeException $e) {
+        }
+
+        return false;
+    }
+
+    /**
+     * @return bool
+     * @throws RuntimeException
+     */
+    public function validateWithExceptions()
+    {
+        try {
+            $address = $this->address->address();
+
+            if (strlen($address) < self::MIN_LENGTH) {
+                return false;
+            }
+
+            if (!preg_match('/[a-z0-9]+/', $address)) {
+                return false;
+            }
+
+            $base58 = new Base58();
+            $binaryDecoded = $base58->decodeHex($address);
+            $hexDecoded = bin2hex($binaryDecoded);
+
+            if (!\ctype_xdigit($hexDecoded) || strlen($hexDecoded) % 2 !== 0) {
+                return false;
+            }
+            return true;
+        } catch (\InvalidArgumentException $e) {
+        } catch (\Exception $e) {
+        }
+
+        return false;
+    }
+}

--- a/src/Address/Validator/Sol.php
+++ b/src/Address/Validator/Sol.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 use RuntimeException;
-use WalletAddressValidator\Address\AddressInterface;
-use WalletAddressValidator\Address\Validator\Codec\Base58;
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base58;
 
 class Sol implements ValidatorInterface
 {

--- a/src/Address/Validator/Support/CashAddress.php
+++ b/src/Address/Validator/Support/CashAddress.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator\Support;
+namespace Exads\WalletAddressValidator\Address\Validator\Support;
 
 class CashAddress
 {

--- a/src/Address/Validator/TRC20.php
+++ b/src/Address/Validator/TRC20.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\AddressInterface;
-use WalletAddressValidator\Address\Validator\Codec\Base58;
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base58;
 
 class TRC20 implements ValidatorInterface
 {

--- a/src/Address/Validator/ValidatorInterface.php
+++ b/src/Address/Validator/ValidatorInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\AddressInterface;
 
 interface ValidatorInterface
 {

--- a/src/Address/Validator/Xem.php
+++ b/src/Address/Validator/Xem.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\AddressInterface;
-use WalletAddressValidator\Address\Validator\Codec\Base32;
-use WalletAddressValidator\Address\Validator\Codec\Keccak;
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base32;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Keccak;
 
 /**
  * https://github.com/QuantumMechanics/NEM-sdk#72---verify-address-validity

--- a/src/Address/Validator/Xlm.php
+++ b/src/Address/Validator/Xlm.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\AddressInterface;
-use WalletAddressValidator\Address\Validator\Codec\Base32;
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base32;
 
 class Xlm implements ValidatorInterface
 {

--- a/src/Address/Validator/Xmr.php
+++ b/src/Address/Validator/Xmr.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\AddressInterface;
-use WalletAddressValidator\Address\Validator\Codec\Base58;
-use WalletAddressValidator\Address\Validator\Codec\Keccak;
+use Exads\WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base58;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Keccak;
 
 /**
  * Class Xmr

--- a/src/Address/Validator/Xrp.php
+++ b/src/Address/Validator/Xrp.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\Validator\Codec\Base58;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base58;
 
 class Xrp extends AbstractBase58
 {

--- a/src/Address/Validator/Xtz.php
+++ b/src/Address/Validator/Xtz.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
-use WalletAddressValidator\Address\Validator\Codec\Base58;
+use Exads\WalletAddressValidator\Address\Validator\Codec\Base58;
 
 class Xtz extends AbstractBase58
 {

--- a/src/Address/Validator/Zec.php
+++ b/src/Address/Validator/Zec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator\Address\Validator;
+namespace Exads\WalletAddressValidator\Address\Validator;
 
 class Zec extends AbstractBase58
 {

--- a/src/AddressFactory.php
+++ b/src/AddressFactory.php
@@ -9,6 +9,15 @@ class AddressFactory
     public static function create(string $symbol, string $network, string $address): AddressInterface
     {
         $class  = '\WalletAddressValidator\Address\Asset\\' . ucfirst(strtolower($symbol));
+        if (openlog('DEBUG', LOG_PID, LOG_LOCAL3)) {
+            $logData = [
+                'class' => $class
+            ];
+            syslog(LOG_NOTICE, json_encode($logData, JSON_PRETTY_PRINT));
+
+            closelog();
+        }
+
         if (! class_exists($class)) {
             throw new \OutOfBoundsException("Address class: {$class} could not found.");
         }

--- a/src/AddressFactory.php
+++ b/src/AddressFactory.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace WalletAddressValidator;
+namespace Exads\WalletAddressValidator;
 
-use WalletAddressValidator\Address\AddressInterface;
+use Exads\WalletAddressValidator\Address\AddressInterface;
 
 class AddressFactory
 {
     public static function create(string $symbol, string $network, string $address): AddressInterface
     {
-        $class  = '\WalletAddressValidator\Address\Asset\\' . ucfirst(strtolower($symbol));
+        $class  = '\Exads\WalletAddressValidator\Address\Asset\\' . ucfirst(strtolower($symbol));
 
         if (! class_exists($class)) {
             throw new \OutOfBoundsException("Address class: {$class} could not found.");

--- a/src/AddressFactory.php
+++ b/src/AddressFactory.php
@@ -9,14 +9,6 @@ class AddressFactory
     public static function create(string $symbol, string $network, string $address): AddressInterface
     {
         $class  = '\WalletAddressValidator\Address\Asset\\' . ucfirst(strtolower($symbol));
-        if (openlog('DEBUG', LOG_PID, LOG_LOCAL3)) {
-            $logData = [
-                'class' => $class
-            ];
-            syslog(LOG_NOTICE, json_encode($logData, JSON_PRETTY_PRINT));
-
-            closelog();
-        }
 
         if (! class_exists($class)) {
             throw new \OutOfBoundsException("Address class: {$class} could not found.");

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WalletAddressValidator;
+namespace Exads\WalletAddressValidator;
 
 class Validator
 {

--- a/tests/AddressTest.php
+++ b/tests/AddressTest.php
@@ -61,6 +61,13 @@ class AddressTest extends TestCase
             'MF7vDsRKMfKvQBQVjheMrtFR45SXhYvkzj' => true,
             '0x25bb155b18958983bb380e738bf676169e7cd531' => false, // BEP20
             'bnb136ns6lfw4zs5hg4n85vdthaad7hq5m4gtkgf23'=> ['memo'=> '104067442', 'assertion' => false], // BEP2
+
+            //LTC Bech32 (SegWit)
+            'ltc1qyleqvngzzqfa6dgn93eafsr0ezzx7f5l85xxn5' => true,
+            'ltc1qggj4z2a845m4hzvmxdcrqyt9dkzedrtt5ym8nx' => true,
+            'ltc1qg42tkwuuxefutzxezdkdel39gfstuap288mfea' => true,
+            'tltc1qu78xur5xnq6fjy83amy0qcjfau8m367defyhms' => true,
+            'Ltc1qv6tqa6enk8kqpz9a83lnmth4km53u9ttleg76l' => false,
         ]));
     }
 

--- a/tests/AddressTest.php
+++ b/tests/AddressTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WalletAddressValidator\Test;
+namespace Exads\WalletAddressValidator\Test;
 
 use PHPUnit\Framework\TestCase;
-use WalletAddressValidator\Address\Network;
-use WalletAddressValidator\AddressFactory;
-use WalletAddressValidator\Validator;
+use Exads\WalletAddressValidator\Address\Network;
+use Exads\WalletAddressValidator\AddressFactory;
+use Exads\WalletAddressValidator\Validator;
 
 class AddressTest extends TestCase
 {

--- a/tests/AddressTest.php
+++ b/tests/AddressTest.php
@@ -253,8 +253,11 @@ class AddressTest extends TestCase
         $this->tryAddresses('USDT', 'OMNI', $this->withCommons([
             '1KL6n25utGRYXWyiU1SJkaqrYWYD6FurEo' => true,
             '1451oXRTetETBi5sFKLSLuwoL2vNR48x2U' => true,
+            '3MbYQMMmSkC3AgWkj9FMo5LsPTW1zBTwXL' => true,
+            '0x9ec7d40d627ec59981446a6e5acb33d51afcaf8a' => true,
             'TNGNYjStMYALYbCQBmwTb1rjgutUQtQYHC' => false, // TRC20
             '0x25bb155b18958983bb380e738bf676169e7cd531' => false, // BEP20
+            '0x9ec7d40d627ec59981446a6e5acb33d51afcaf8a' => false,
             'bnb136ns6lfw4zs5hg4n85vdthaad7hq5m4gtkgf23'=> ['memo'=> '104067442', 'assertion' => false], // BEP2
         ]));
 
@@ -262,6 +265,15 @@ class AddressTest extends TestCase
             'TNGNYjStMYALYbCQBmwTb1rjgutUQtQYHC' => true,
             '1KL6n25utGRYXWyiU1SJkaqrYWYD6FurEo' => false,
             '0x5e8306c6f9c46cd48522a2aab5d7cbb1c5f2ede9' => false, // ERC20
+        ]));
+
+        $this->tryAddresses('USDT', 'BEP20', $this->withCommons([
+            '0xdbe82367ce536e685b8e4496e172e26b442dd7c7' => true, // BEP20
+        ]));
+
+        $this->tryAddresses('USDT', 'POLYGON', $this->withCommons([
+            '0xBa3F83aCd6DeFF56b873DBd2b05971002EaD6231' => true, // Polygon
+            '0x35342fe71e28df1308e5ab74d2c111938aa9f4bf' => true, // Polygon
         ]));
     }
 
@@ -351,6 +363,7 @@ class AddressTest extends TestCase
                 'USDT-OMNI' => Network::OMNI,
                 'USDT-ERC20' => Network::ERC20,
                 'USDT-TRC20' => Network::TRC20,
+                'USDT-BEP20' => Network::BEP20
             ],
             'BTC' => [
                 'SOMETHING-ELSE' => Network::BTC
@@ -362,6 +375,7 @@ class AddressTest extends TestCase
         $this->assertTrue(Validator::isValid('USDT', 'USDT-ERC20', '0x5e8306c6f9c46cd48522a2aab5d7cbb1c5f2ede9'));
         $this->assertTrue(Validator::isValid('USDT', 'USDT-TRC20', 'TNGNYjStMYALYbCQBmwTb1rjgutUQtQYHC'));
         $this->assertTrue(Validator::isValid('BTC', 'SOMETHING-ELSE', '1LNkDkf4rtKRozGTpPRbPtYJnY2q5N5bFW'));
+        $this->assertTrue(Validator::isValid('USDT', 'USDT-BEP20', '0xBa3F83aCd6DeFF56b873DBd2b05971002EaD6231'));
     }
 
     protected function tryAddresses(string $symbol, string $network, array $addresses): void


### PR DESCRIPTION
The **kielabokkie/bitcoin-address-validator** package is added to the composer.json, composer.lock is in gitignore so I decided to keep it as it is.
The **kielabokkie/bitcoin-address-validator** is already used in the **exads-core** so I decided to choose the same lib

In order to make minimum changes to the existing code I moved the validation logic to Validator/Ltc directory
